### PR TITLE
Changed file type detection to reflect new lowercase default behavior

### DIFF
--- a/ftdetect/todo.vim
+++ b/ftdetect/todo.vim
@@ -5,5 +5,5 @@
 " Website:     http://github.com/freitass/todo.txt.vim
 " Version:     0.1
 
-autocmd BufNewFile,BufRead Todo.txt set filetype=todo
+autocmd BufNewFile,BufRead [Tt]odo.txt set filetype=todo
 


### PR DESCRIPTION
When creating a new todo/ directory structure from the Android app last
week I noticed new todo files are now (have always been?) created all
lowercase.

Therefore I made a trivial change to ftdetect/todo.vim to make the plugin
recognize both Todo.txt as well as todo.txt and switch to todo mode
accordingly.
