### PR TITLE
Fix documentation and README typos

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,9 +19,9 @@ This plugin gives syntax highlighting to [todo.txt](http://todotxt.com/) files. 
 
 `<leader>-a` : Add the priority (A) to the current line
 
-`<leader>-c` : Add the priority (B) to the current line
+`<leader>-b` : Add the priority (B) to the current line
 
-`<leader>-b` : Add the priority (C) to the current line
+`<leader>-c` : Add the priority (C) to the current line
 
 `<leader>-d` : Insert the current date
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -15,9 +15,9 @@ COMMANDS                                                       *todo-commands*
 
 `<leader>-a` : Add the priority (A) to the current line
 
-`<leader>-c` : Add the priority (B) to the current line
+`<leader>-b` : Add the priority (B) to the current line
 
-`<leader>-b` : Add the priority (C) to the current line
+`<leader>-c` : Add the priority (C) to the current line
 
 `<leader>-d` : Insert the current date
 


### PR DESCRIPTION
The commands for adding priorities B and C got switched up in the
documentation and README.
