### PR TITLE
When sorting on priority, sort also on projects and contexts

### DIFF
--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -64,10 +64,18 @@ function! TodoTxtRemoveCompleted()
     call s:AppendToFile(l:done_file, l:completed)
 endfunction
 
+function! TodoTxtSort()
+    " vim :sort is usually stable
+    " we sort first on contexts, then on projects and then on priority
+    :sort /@[a-zA-Z]*/ r
+    :sort /+[a-zA-Z]*/ r
+    :sort /\v\([A-Z]\)/ r
+endfunction
+
 " Mappings {{{1
 " Sort tasks {{{2
 if !hasmapto("<leader>s",'n')
-    nnoremap <script> <silent> <buffer> <leader>s :sort<CR>
+    nnoremap <script> <silent> <buffer> <leader>s :call TodoTxtSort()<CR>
 endif
 
 if !hasmapto("<leader>s@",'n')


### PR DESCRIPTION
After pressing <leader>s, todo.vim used to sort all lines
alphabetically. This caused tasks related to different projects to be
placed apart from each other - the whole list was then difficult to
follow.

This patch fixes this by taking into account the fact that :sort in vim
is usually stable (see http://en.wikipedia.org/wiki/Sorting_algorithm#Stability),
so that when we sort first on contexts, then on projects and then on
priority, everything is placed in the order we want.