### PR TITLE
make <leader>a replace set priority, even if it's already set

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,11 +17,11 @@ This plugin gives syntax highlighting to [todo.txt](http://todotxt.com/) files. 
 
 `<leader>-k` : Increase the priority of the current line
 
-`<leader>-a` : Add the priority (A) to the current line
+`<leader>-a` : Set the priority of the current line to (A)
 
-`<leader>-b` : Add the priority (B) to the current line
+`<leader>-b` : Set the priority of the current line to (B)
 
-`<leader>-c` : Add the priority (C) to the current line
+`<leader>-c` : Set the priority of the current line to (C)
 
 `<leader>-d` : Insert the current date
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -13,11 +13,11 @@ COMMANDS                                                       *todo-commands*
 
 `<leader>-k` : Increase the priority of the current line
 
-`<leader>-a` : Add the priority (A) to the current line
+`<leader>-a` : Set the priority of the current line to (A)
 
-`<leader>-b` : Add the priority (B) to the current line
+`<leader>-b` : Set the priority of the current line to (B)
 
-`<leader>-c` : Add the priority (C) to the current line
+`<leader>-c` : Set the priority of the current line to (C)
 
 `<leader>-d` : Insert the current date
 

--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -83,21 +83,40 @@ endif
 " Increment and Decrement The Priority
 :set nf=octal,hex,alpha
 
+function! TodoTxtGetPriority()
+    if match(getline('.'), '^(\w)') == 0
+        let l:priority = strpart(getline('.'), 1, 1)
+    elseif match(getline('.'), '^x') == 0
+        let l:priority = 'x'
+    endif
+
+    return l:priority
+endfunction
+
 function! TodoTxtPrioritizeIncrease()
-    normal! 0f)h
+    if TodoTxtGetPriority() != ''
+        normal! 0f)h
+    endif
 endfunction
 
 function! TodoTxtPrioritizeDecrease()
-    normal! 0f)h
+    if TodoTxtGetPriority() != ''
+        normal! 0f)h
+    endif
 endfunction
 
 function! TodoTxtPrioritizeAdd (priority)
-    " Need to figure out how to only do this if the first visible letter in a line is not (
     :call TodoTxtPrioritizeAddAction(a:priority)
 endfunction
 
 function! TodoTxtPrioritizeAddAction (priority)
-    execute "normal! mq0i(".a:priority.") \<esc>`q"
+    if TodoTxtGetPriority() == ''
+        execute "normal! mq0i(".a:priority.") \<esc>`q"
+    elseif TodoTxtGetPriority() == 'x'
+        execute "normal! mq0s(".a:priority.")\<esc>`q"
+    else
+        execute "normal! mq03s(".a:priority.")\<esc>`q"
+    endif
 endfunction
 
 if !hasmapto("<leader>j",'n')


### PR DESCRIPTION
This pull request makes the `<leader>[a,b,c]` functions replace the current priority, if it exists, and also prevents the priority modification functions from matching lines with no priority, with parentheses in them, e.g.

    some todo (not a priority)

previously in this case, the 'y' would be modified with the increase/decrease priority functions.