### PR TITLE
add ability to sort on due dates

### DIFF
--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -93,6 +93,12 @@ function! todo#txt#sort_by_date() range
     execute a:firstline . "," . a:lastline . "g!/" . l:date_regex . "/m" . a:lastline
 endfunction
 
+function! todo#txt#sort_by_due_date() range
+    let l:date_regex = "due:\\d\\{2,4\\}-\\d\\{2\\}-\\d\\{2\\}"
+    execute a:firstline . "," . a:lastline . "sort /" . l:date_regex . "/ r"
+    execute a:firstline . "," . a:lastline . "g!/" . l:date_regex . "/m" . a:lastline
+endfunction
+
 " Increment and Decrement The Priority
 :set nf=octal,hex,alpha
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -25,6 +25,7 @@ CONTENTS                                                       *todo-contents*
 	`<localleader>s+`  Sort the file on +Projects
 	`<localleader>s@`  Sort the file on @Contexts
 	`<localleader>sd`  Sort the file on dates
+	`<localleader>sdd` Sort the file on due dates (i.e. due:2015-10-25)
 	
 1.2 Edit priority:                                    *todo-commands-priority*
 	`<localleader>j`   Decrease the priority of the current line

--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -26,6 +26,8 @@ nnoremap <script> <silent> <buffer> <localleader>s+ :%call todo#txt#sort_by_proj
 vnoremap <script> <silent> <buffer> <localleader>s+ :call todo#txt#sort_by_project()<CR>
 nnoremap <script> <silent> <buffer> <localleader>sd :%call todo#txt#sort_by_date()<CR>
 vnoremap <script> <silent> <buffer> <localleader>sd :call todo#txt#sort_by_date()<CR>
+nnoremap <script> <silent> <buffer> <localleader>sdd :%call todo#txt#sort_by_due_date()<CR>
+vnoremap <script> <silent> <buffer> <localleader>sdd :call todo#txt#sort_by_due_date()<CR>
 
 " Change priority {{{2
 nnoremap <script> <silent> <buffer> <localleader>j :call todo#txt#prioritize_increase()<CR>


### PR DESCRIPTION
This sorts todo.txt files on due dates, i.e. `(A) send rent check due:2015-11-01`. See [the todo.txt spec](https://github.com/ginatrapani/todo.txt-cli/wiki/The-Todo.txt-Format) for the format. 