### PR TITLE
Fix wrong prefix for completed tasks

### DIFF
--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -41,7 +41,7 @@ endfunction
 function! todo#txt#mark_as_done()
     call s:remove_priority()
     call todo#txt#prepend_date()
-    normal! Ix
+    execute 'normal! Ix '
 endfunction
 
 function! todo#txt#mark_all_as_done()


### PR DESCRIPTION
The commit a612ebe ('Remove trailing whitespaces') removed the
whitespace which was after 'x' markup. It caused to mark the
completed task without space and didn't allow to remove it
automatically.

Before this change:
xCOMPLETION_DATE ....
After this change:
x COMPLETION_DATE ...

Fixes: a612ebe ('Remove trailing whitespaces')
Signed-off-by: Leon Romanovsky <leon@leon.nu>