### PR TITLE
vim python3 compatibility

### DIFF
--- a/syntax/python/dateregex/dateregex/__init__.py
+++ b/syntax/python/dateregex/dateregex/__init__.py
@@ -7,5 +7,5 @@
 # Website:     http://github.com/freitass/todo.txt-vim
 # Version:     0.1
 
-from after import regex_date_after
-from before import regex_date_before
+from dateregex.after import regex_date_after
+from dateregex.before import regex_date_before

--- a/syntax/todo.vim
+++ b/syntax/todo.vim
@@ -54,6 +54,10 @@ if has('python')
     let b:curdir = expand('<sfile>:p:h')
     let s:script_dir = b:curdir . "/python/"
     execute "pyfile " . s:script_dir. "todo.py"
+elseif has('python3')
+        let b:curdir = expand('<sfile>:p:h')
+        let s:script_dir = b:curdir . "/python/"
+        execute "py3file " . s:script_dir. "todo.py"
 else
     echom "Your version of vim has no python support. Overdue dates won't be highlighted"
 endif


### PR DESCRIPTION
On newest linux distribution (ubuntu 16.04 LTS for example), vim is now often linked with python3 instead of python2 (+python3). Ensure compatibility with it (your code was compatible, except one import in the __init__.py of the module and a check in the vim part). 