### PR TITLE
Fix incorrect/duplicate helptag

### DIFF
--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -56,7 +56,7 @@ date of creation: >
   r - replace existing date (default)
   n - do nothing
 
-                                                      *'g:todo_existing_date'*
+                                                      *'g:todo_load_python'*
 Specify if the plugin should load the python module. Useful if you use Neovim
 for example or if perhaps you just don't have/want python for vim: >
   let g:todo_load_python = 1


### PR DESCRIPTION
I was getting this error:

```
E154: Duplicate tag "'g:todo_existing_date'" in file /home/awlayton/.vim/bundle/
todo.txt-vim//doc/todo.txt
```

I believe this commit is the correct fix.
