### PR TITLE
Fix overduedate regex breaking in November

### DIFF
--- a/syntax/python/dateregex/dateregex/before.py
+++ b/syntax/python/dateregex/dateregex/before.py
@@ -44,7 +44,7 @@ def _month_regex_before(year, month):
 def _day_regex_before(year, month, day):
     if day == '01':
         return None
-    last_month_day = str((date(int(year), (int(month) + 1) % 12, 1) + - date.resolution).day)
+    last_month_day = str((date(int(year), int(month) % 12 + 1, 1) + - date.resolution).day)
     last_digit1, last_digit2 = last_month_day
 
     digit1, digit2 = day


### PR DESCRIPTION
There was a bug on the python script that generates the regex for overdue dates, breaking only in November.

See https://github.com/dbeniamine/todo.txt-vim/issues/9 for more info.