### PR TITLE
Plugin for todo.sh used to open the correct todo.txt file in vi

### DIFF
--- a/.todo.actions.d/vi
+++ b/.todo.actions.d/vi
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ $1 == "usage" ]]; then
+   echo "todo.sh vi [extra args]: opens todo.txt file in vi, with optional commands provided " 
+else
+   vi "${@:2}"  $TODO_FILE 
+fi

--- a/README.markdown
+++ b/README.markdown
@@ -13,6 +13,8 @@ If your Vim installation does **not** have Python support, this plugin **will wo
     git clone git://github.com/freitass/todo.txt-vim.git
     cd todo.txt-vim
     cp -R * ~/.vim
+    #optional: add a vi plugin to todo.sh
+    ln -s ~/.vim/.todo.actions.d/vi ~/.todo.actions.d/vi
 
 
 This plugin gives syntax highlighting to [todo.txt](http://todotxt.com/) files. It also defines a few mappings, to help with editing these files:


### PR DESCRIPTION
I created a shortcut to open the correct todo.txt files in vi, taking advantage of the enviromental variables provided to todo.sh plugins 

