### PR TITLE
Start date sorting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,7 @@ Sorting tasks:
 `<localleader>s@`  Sort the file on @Contexts  
 `<localleader>sd`  Sort the file on dates  
 `<localleader>sdd`  Sort the file on due dates  
+`<localleader>sdt`  Sort the file on start dates as represented by the "t" metadata key (e.g., "t:2017-11-23")
 
 Edit priority:  
 `<localleader>j`   Decrease the priority of the current line  

--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -99,6 +99,12 @@ function! todo#txt#sort_by_due_date() range
     execute a:firstline . "," . a:lastline . "g!/" . l:date_regex . "/m" . a:lastline
 endfunction
 
+function! todo#txt#sort_by_start_date() range
+    let l:date_regex = "t:\\d\\{2,4\\}-\\d\\{2\\}-\\d\\{2\\}"
+    execute a:firstline . "," . a:lastline . "sort /" . l:date_regex . "/ r"
+    execute a:firstline . "," . a:lastline . "g!/" . l:date_regex . "/m" . a:lastline
+endfunction
+
 " Increment and Decrement The Priority
 :set nf=octal,hex,alpha
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -26,6 +26,7 @@ CONTENTS                                                       *todo-contents*
 	`<localleader>s@`  Sort the file on @Contexts
 	`<localleader>sd`  Sort the file on dates
 	`<localleader>sdd` Sort the file on due dates (i.e. due:2015-10-25)
+	<localleader>sdt Sort the file on due dates (i.e. t:2015-10-25)
 
 1.2 Edit priority:                                    *todo-commands-priority*
 	`<localleader>j`   Decrease the priority of the current line

--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -28,6 +28,8 @@ nnoremap <script> <silent> <buffer> <localleader>sd :%call todo#txt#sort_by_date
 vnoremap <script> <silent> <buffer> <localleader>sd :call todo#txt#sort_by_date()<CR>
 nnoremap <script> <silent> <buffer> <localleader>sdd :%call todo#txt#sort_by_due_date()<CR>
 vnoremap <script> <silent> <buffer> <localleader>sdd :call todo#txt#sort_by_due_date()<CR>
+nnoremap <script> <silent> <buffer> <localleader>sdt :%call todo#txt#sort_by_start_date()<CR>
+vnoremap <script> <silent> <buffer> <localleader>sdt :call todo#txt#sort_by_start_date()<CR>
 
 " Change priority {{{2
 nnoremap <script> <silent> <buffer> <localleader>j :call todo#txt#prioritize_increase()<CR>


### PR DESCRIPTION
Support start date sorting. Uses the "t" metadata key for start date
(e.g., "t:2017-11-23") as implemented by Simpletask
(https://github.com/mpcjanssen/simpletask-android).