### PR TITLE
Fix function name for folding

### DIFF
--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -59,11 +59,11 @@ nnoremap <script> <silent> <buffer> <localleader>D :call todo#txt#remove_complet
 " Folding {{{1
 " Options {{{2
 setlocal foldmethod=expr
-setlocal foldexpr=s:todo_fold_level(v:lnum)
-setlocal foldtext=s:todo_fold_text()
+setlocal foldexpr=Todo_fold_level(v:lnum)
+setlocal foldtext=Todo_fold_text()
 
-" s:todo_fold_level(lnum) {{{2
-function! s:todo_fold_level(lnum)
+" Todo_fold_level(lnum) {{{2
+function! Todo_fold_level(lnum)
     " The match function returns the index of the matching pattern or -1 if
     " the pattern doesn't match. In this case, we always try to match a
     " completed task from the beginning of the line so that the matching
@@ -75,8 +75,8 @@ function! s:todo_fold_level(lnum)
     return match(getline(a:lnum),'^[xX]\s.\+$') + 1
 endfunction
 
-" s:todo_fold_text() {{{2
-function! s:todo_fold_text()
+" Todo_fold_text() {{{2
+function! Todo_fold_text()
     " The text displayed at the fold is formatted as '+- N Completed tasks'
     " where N is the number of lines folded.
     return '+' . v:folddashes . ' '


### PR DESCRIPTION
'foldexpr' & 'foldtext' do not detect script functions

### Reproduce way

Vim 8.0.1283
Nvim v0.3.1

```sh
mkdir /tmp/vim
cd /tmp/vim
git clone https://github.com/freitass/todo.txt-vim
vim vimrc
```

```vim
set runtimepath+=/tmp/vim/todo.txt-vim
syntax enable
filetype plugin on
```

```sh
vim -N -u vimrc -U NONE -i NONE
:e /path/to/todo.txt
```