### PR TITLE
add focus/ignore mappings

### DIFF
--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -56,6 +56,11 @@ nnoremap <script> <silent> <buffer> <localleader>X :call todo#txt#mark_all_as_do
 " Remove completed {{{2
 nnoremap <script> <silent> <buffer> <localleader>D :call todo#txt#remove_completed()<CR>
 
+" Move-to-top/bottom {{{2
+" mnemonic: "Focus" / "Ignore"
+nnoremap <script> <silent> <buffer> <localleader>f *:g//m0<CR>:g//m0<CR>gg
+nnoremap <script> <silent> <buffer> <localleader>i *:g//m$<CR>gg
+
 " Folding {{{1
 " Options {{{2
 setlocal foldmethod=expr


### PR DESCRIPTION
Given more todo.txt items than fit on the screen...

I am aware of `<leader>s....` for sorting by priority, tag, context, etc.

This patch adds `<leader>f`, `<leader>i` mnemonic focus/ignore for word under cursor.

Use case is to navigate to a tag (`/+work`), and then `<leader>f` which maintains previous sort, but brings all items with that tag _up_ to the top of the file (focus).  Conversely: `/+home<cr>`, `<leader>i` would  "ignore" items tagged with `home`.

Please try it out, give feedback, and consider for inclusion.  With local leader of `,` the interaction would be something like:

```
,s              ... sort todos by default priority
/+work<cr>      ... search for "work"
,f              ... "focus" on work (word under cursor, move to top)
/+personal<cr>  ... search for "personal"
,i              ... "ignore" personal (word under cursor, move to bottom)
ggn             ... go back to "personal" block at bottom of file
VG              ... visually grab "personal" through end of file
,jk             ... de-prioritize all "personal" items
,s              ... re-sort by priority
```

...if there is interest in the feature / functionality, or improvements to it, I'd be willing to try and champion a feature like this and integrate feedback, etc.