### PR TITLE
Go to end of line and into insert mode after add item

### DIFF
--- a/ftplugin/todo.vim
+++ b/ftplugin/todo.vim
@@ -34,11 +34,11 @@ nnoremap <script> <silent> <buffer> <localleader>j :call todo#txt#prioritize_inc
 vnoremap <script> <silent> <buffer> <localleader>j :call todo#txt#prioritize_increase()<CR>
 nnoremap <script> <silent> <buffer> <localleader>k :call todo#txt#prioritize_decrease()<CR>
 vnoremap <script> <silent> <buffer> <localleader>k :call todo#txt#prioritize_decrease()<CR>
-nnoremap <script> <silent> <buffer> <localleader>a :call todo#txt#prioritize_add('A')<CR>
+nnoremap <script> <silent> <buffer> <localleader>a :call todo#txt#prioritize_add('A')<CR>A
 vnoremap <script> <silent> <buffer> <localleader>a :call todo#txt#prioritize_add('A')<CR>
-nnoremap <script> <silent> <buffer> <localleader>b :call todo#txt#prioritize_add('B')<CR>
+nnoremap <script> <silent> <buffer> <localleader>b :call todo#txt#prioritize_add('B')<CR>A
 vnoremap <script> <silent> <buffer> <localleader>b :call todo#txt#prioritize_add('B')<CR>
-nnoremap <script> <silent> <buffer> <localleader>c :call todo#txt#prioritize_add('C')<CR>
+nnoremap <script> <silent> <buffer> <localleader>c :call todo#txt#prioritize_add('C')<CR>A
 vnoremap <script> <silent> <buffer> <localleader>c :call todo#txt#prioritize_add('C')<CR>
 
 " Insert date {{{2


### PR DESCRIPTION
I think it is annoying always having to go into insert mode and at the end of the line after adding a new todo item.
I want to start typing right after `<localleader>a` for example.
This commit does that. 