### PR TITLE
Custom done.txt filename option

### DIFF
--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -71,7 +71,7 @@ function! todo#txt#remove_completed()
     " Check for user-defined g:todo_done_filename
     if exists("g:todo_done_filename")
         let l:todo_done_filename = g:todo_done_filename
-    elseif expand('%:t') = 'Todo.txt'
+    elseif expand('%:t') == 'Todo.txt'
         let l:todo_done_filename = 'Done.txt'
     else
         let l:todo_done_filename = 'done.txt'

--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -68,9 +68,17 @@ function! todo#txt#remove_completed()
 
     let l:target_dir = expand('%:p:h')
     let l:todo_file = expand('%:p')
-    let l:done_file = substitute(substitute(l:todo_file, 'todo.txt$', 'done.txt', ''), 'Todo.txt$', 'Done.txt', '')
+    " Check for user-defined g:todo_done_filename
+    if exists("g:todo_done_filename")
+        let l:todo_done_filename = g:todo_done_filename
+    elseif expand('%:t') = 'Todo.txt'
+        let l:todo_done_filename = 'Done.txt'
+    else
+        let l:todo_done_filename = 'done.txt'
+    endif
+    let l:done_file = substitute(substitute(l:todo_file, 'todo.txt$', l:todo_done_filename, ''), 'Todo.txt$', l:todo_done_filename, '')
     if !filewritable(l:done_file) && !filewritable(l:target_dir)
-        echoerr "Can't write to file 'done.txt'"
+        echoerr "Can't write to file '" . l:todo_done_filename . "'"
         return
     endif
 

--- a/doc/todo.txt
+++ b/doc/todo.txt
@@ -64,5 +64,12 @@ for example or if perhaps you just don't have/want python for vim: >
   1 - Load (default)
   0 - Don't load
 
+                                                      *'g:todo_done_filename'*
+Specify a custom filename for completed todo entries to be archived to. Useful
+for compatibility with other todo.txt editors, or as a matter of preference:
+  let g:todo_done_filename = 'completed.txt'
+
+   Default: Done.txt or done.txt based on todo.txt capitalization.
+
 ===============================================================================
 vim:ft=help:et:ts=2:sw=2:sts=2:norl


### PR DESCRIPTION
Allow users to define a custom done.txt filename convention in their vimrc's for compatibility with other editors and variations of the todo.txt scheme.