### PR TITLE
Prefer: `0i` instead of `I` for mechanical insertion

### DIFF
--- a/autoload/todo/txt.vim
+++ b/autoload/todo/txt.vim
@@ -26,7 +26,7 @@ function! s:get_current_date()
 endfunction
 
 function! todo#txt#prepend_date()
-    execute 'normal! I' . s:get_current_date() . ' '
+    execute 'normal! 0i' . s:get_current_date() . ' '
 endfunction
 
 function! todo#txt#replace_date()
@@ -41,7 +41,7 @@ endfunction
 function! todo#txt#mark_as_done()
     call s:remove_priority()
     call todo#txt#prepend_date()
-    execute 'normal! Ix '
+    execute 'normal! 0ix '
 endfunction
 
 function! todo#txt#mark_all_as_done()


### PR DESCRIPTION
vim details: `I` inserts before the first character instead of `0i` which inserts at the beginning of the line.

Usually `I` inserts at the first character in the line, and usually the first character is on the far left.  However, `I` ignores leading spaces which conflicts a bit with the mechanical manipulation of the text.

While it's not great `todo.txt` practices, if you did "mark as done" while on a line like ` * ...etc...` (eg: an indented bullet), the `I...` would put the `x` away from the far left (not the first character on the line, but instead the first character before the first character).

Prefer: `0i` instead of `I` for mechanical insertion